### PR TITLE
Fix UTC offset for EDT

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
             <h5 class="text-xl font-semibold mb-2">Next Meeting</h5>
             <h2>Sunday, August 31, 2025</h2>
             <!-- Would be real cool to offer it in their timezone here. -->
-            <h3>11:00 AM EDT (UTC-5)</h3>
+            <h3>11:00 AM EDT (UTC-4)</h3>
             <p>Agenda: Review Chapter 12.</p>
             <p>Meetings are held every two weeks.</p>
 


### PR DESCRIPTION
As noted on https://www.timeanddate.com/time/zones/edt EDT is 4 hours behind UTC rather than 5.

Hence, update the index page to reflect this.